### PR TITLE
use default identity values if not defined

### DIFF
--- a/src/strophe.disco.js
+++ b/src/strophe.disco.js
@@ -36,6 +36,12 @@ Strophe.addConnectionPlugin('disco',
      */
     addIdentity: function(category, type, name, lang)
     {
+        if (typeof name === 'undefined') {
+           name = '';
+        }
+        if (typeof lang === 'undefined') {
+           lang = '';
+        }
         for (var i=0; i<this._identities.length; i++)
         {
             if (this._identities[i].category == category &&


### PR DESCRIPTION
as described in https://xmpp.org/extensions/xep-0115.html#ver-gen name and lang are optional

reported in jsxc/jsxc#588